### PR TITLE
Background color option

### DIFF
--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -69,6 +69,9 @@ void usage ()
     .type_image_in ();
 
   GUI::MRView::Window::add_commandline_options (OPTIONS);
+  //  + Option ("background_color",
+  //            "The background color, as RGB values ranging from 0 to 1.0, e.g. .5 .5 .5 for grey or 1 0 0 for red")
+  //      + Argument ("value").type_sequence_float()
 
 #define TOOL(classname, name, description) \
   MR::GUI::MRView::Tool::classname::add_commandline_options (OPTIONS);

--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -68,11 +68,6 @@ void usage ()
     .allow_multiple()
     .type_image_in ();
 
-  GUI::MRView::Window::add_commandline_options (OPTIONS);
-  //  + Option ("background_color",
-  //            "The background color, as RGB values ranging from 0 to 1.0, e.g. .5 .5 .5 for grey or 1 0 0 for red")
-  //      + Argument ("value").type_sequence_float()
-
 #define TOOL(classname, name, description) \
   MR::GUI::MRView::Tool::classname::add_commandline_options (OPTIONS);
   {

--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -68,6 +68,8 @@ void usage ()
     .allow_multiple()
     .type_image_in ();
 
+  GUI::MRView::Window::add_commandline_options (OPTIONS);
+
 #define TOOL(classname, name, description) \
   MR::GUI::MRView::Tool::classname::add_commandline_options (OPTIONS);
   {

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -2031,6 +2031,20 @@ namespace MR
             return;
           }
 
+          if (opt.opt->is ("background_colour")) {
+            vector<int> rgb = parse_ints(opt[0]); 
+            try {
+              QColor colour (rgb[0], rgb[1], rgb[2], 255); 
+              if (colour.isValid()) { 
+                background_colour[0] = GLubyte(colour.red()) / 255.0f;
+                background_colour[1] = GLubyte(colour.green()) / 255.0f;
+                background_colour[2] = GLubyte(colour.blue()) / 255.0f;
+              }
+            }
+            catch (Exception E) {
+              throw Exception ("background_colour option: invalid colour");
+            }
+          }
 
           if (opt.opt->is ("fps")) {
             show_FPS = true;
@@ -2122,6 +2136,9 @@ namespace MR
 
           + Option ("intensity_range", "Set the image intensity range to that specified.").allow_multiple()
           +   Argument ("min,max").type_sequence_float()
+
+          + Option ("background_colour", "Set background color").allow_multiple()
+          +   Argument ("R,G,B").type_sequence_int()
 
           + OptionGroup ("Window management options")
 


### PR DESCRIPTION
While most of the data-manipulation can be automated using shell scripts, `mrview` is lacking most of this functionality.

This feature adds a simple `background_colour` option to `mrview`, which takes RGB values.

It's meant to be the first pull request in a series introducing small ease-of-life feature additions to mrview.

Possible issues I can think of when going down this road:
- Priority of these options over config files?
- Option bloat, or inconsistent amount of available options?

Possible issues of this specific request:
- `background_colour` is set once in the beginning for the mrview window, make it work somewhere else, where it's more stable or integrated in the programs logic?
- Takes no precedence over the config file option
- Then again, the config file only affects the SH viewer window, not the main window